### PR TITLE
override play path per job

### DIFF
--- a/src/main/java/com/gmail/ikeike443/PlayAutoTestBuilder.java
+++ b/src/main/java/com/gmail/ikeike443/PlayAutoTestBuilder.java
@@ -28,10 +28,12 @@ import org.kohsuke.stapler.StaplerRequest;
 public class PlayAutoTestBuilder extends Builder{
 
 	private final String play_cmd;
+	private final String play_path;
 
 	@DataBoundConstructor
-	public PlayAutoTestBuilder(String play_cmd) {
+	public PlayAutoTestBuilder(String play_cmd, String play_path) {
 		this.play_cmd = play_cmd;
+		this.play_path = play_path;
 	}
 
 	/**
@@ -41,6 +43,10 @@ public class PlayAutoTestBuilder extends Builder{
 		return play_cmd;
 	}
 
+	public String getPlay_path() {
+		return play_path;
+	}
+	
 	@SuppressWarnings("deprecation")
 	@Override
 	public boolean perform(AbstractBuild build, Launcher launcher, BuildListener listener) {
@@ -58,7 +64,9 @@ public class PlayAutoTestBuilder extends Builder{
 		
 
 		String playpath = null;
-		if(getDescriptor().path()!= null){
+		if(play_path != null || play_path.length() > 0) {
+			playpath = play_path;
+		} else if(getDescriptor().path()!= null){
 			playpath = getDescriptor().path();
 		}else{
 			listener.getLogger().println("play path is null");

--- a/src/main/resources/com/gmail/ikeike443/PlayAutoTestBuilder/config.jelly
+++ b/src/main/resources/com/gmail/ikeike443/PlayAutoTestBuilder/config.jelly
@@ -2,4 +2,9 @@
   <f:entry title="Play command" field="play_cmd" help="/plugin/play-autotest-plugin/help-cmd.html">
     <f:textbox name="play_cmd"/>
   </f:entry>
+  <f:advanced>
+    <f:entry title="Play path override" field="play_path" help="/plugin/play-autotest-plugin/help-path-override.html">
+      <f:textbox name="play_path"/>
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/test/java/com/gmail/ikeike443/PlayAutoTestBuilderTest.java
+++ b/src/test/java/com/gmail/ikeike443/PlayAutoTestBuilderTest.java
@@ -34,7 +34,7 @@ public class PlayAutoTestBuilderTest extends HudsonTestCase {
 	public void testPlayPathIsNull() throws Exception {
 
 		FreeStyleProject pj = createFreeStyleProject("playpathisnull");
-		pj.getBuildersList().add(new PlayAutoTestBuilder("auto-test"));
+		pj.getBuildersList().add(new PlayAutoTestBuilder("auto-test", null));
 		FreeStyleBuild build = pj.scheduleBuild2(0).get();
 		System.out.println(build.getDisplayName()+" completed");
 

--- a/src/test/java/com/gmail/ikeike443/PlayTestResultActionTest.java
+++ b/src/test/java/com/gmail/ikeike443/PlayTestResultActionTest.java
@@ -29,7 +29,7 @@ public class PlayTestResultActionTest extends HudsonTestCase {
 	@Test
 	public void testTestResultIsOK() throws Exception {
 		FreeStyleProject pj = createFreeStyleProject("testsuccess");
-		pj.getBuildersList().add(new PlayAutoTestBuilder("auto-test"));
+		pj.getBuildersList().add(new PlayAutoTestBuilder("auto-test", null));
 		FreeStyleBuild build = pj.scheduleBuild2(0).get();//must be failure but don't care
 		System.out.println(build.getDisplayName()+" completed");
 		//setup
@@ -61,7 +61,7 @@ public class PlayTestResultActionTest extends HudsonTestCase {
 	@Test
 	public void testTestResultIsNG() throws Exception {
 		FreeStyleProject pj = createFreeStyleProject("testfailure");
-		pj.getBuildersList().add(new PlayAutoTestBuilder("auto-test"));
+		pj.getBuildersList().add(new PlayAutoTestBuilder("auto-test", null));
 		FreeStyleBuild build = pj.scheduleBuild2(0).get();//must be failure but don't care
 		System.out.println(build.getDisplayName()+" completed");
 		//setup


### PR DESCRIPTION
This lets me run a script like 

export PLAY_VERSION=1.2.2RC2
if [[ ! -e play-$PLAY_VERSION/play ]]; then
   rm -f play-${PLAY_VERSION}.zip
   wget http://download.playframework.org/releases/play-${PLAY_VERSION}.zip
   unzip play-${PLAY_VERSION}
fi
